### PR TITLE
Allow chromium to run in no-sandbox mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ const yargs = require('yargs');
     type: 'boolean',
     describe: 'Don\'t download invoices'
   });
+  yargs.option('no-sandbox', {
+    type: 'boolean',
+    describe: 'Allow chromium to run without sandbox'
+  });
   yargs.option('d', {
     type: 'string',
     describe: 'Output directory for CSVs and invoices',
@@ -32,12 +36,24 @@ const yargs = require('yargs');
 
   const argv = yargs.argv;
 
-  const browser = await puppeteer.launch({ headless: false, defaultViewport: null });
+  let puppeteer_launch_args = [];
+  if (argv.hasOwnProperty('sandbox')) {
+    puppeteer_launch_args = [
+      '--no-sandbox',
+      '--disable-setuid-sandbox'
+    ];
+  }
+
+  const browser = await puppeteer.launch({
+    headless: false,
+    defaultViewport: null,
+    args: puppeteer_launch_args
+  });
 
   const scraperName = argv._[0];
   const basePath = path.join(argv.d, `${scraperName}`);
   const scrapeOptions = {
-    downloadInvoices: argv.invoices !== false
+    downloadInvoices: !(argv.hasOwnProperty('invoices'))
   };
   /** @type {import("./lib/Scraper")} */
   const scraper = require(`./scrapers/${scraperName}`);


### PR DESCRIPTION
It appears that on some older Linux kernels / installations, Chrome / Chromium can't run because sandboxing isn't supported; and thus WhatDidIBuy fails to launch chromium with an error like the one below.

Chromium supports a command-line option that disables sandboxing, so I've added support for passing through that option from WhatDidIBuy. This solved the error (again shown below). I've also corrected the handling of WhatDidIBuy's "--no-invoices" option, because checking it's value doesn't work as intended (at least on linux).

**Chromium sandbox error:**
```
/home/nick/code/WhatDidIBuy/node_modules/puppeteer/lib/Launcher.js:349
      reject(new Error([
             ^

Error: Failed to launch chrome!
[22097:22097:0804/223953.804681:FATAL:zygote_host_impl_linux.cc(116)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
#0 0x55da2c5c0a99 base::debug::CollectStackTrace()
#1 0x55da2c5213e3 base::debug::StackTrace::StackTrace()
#2 0x55da2c535943 logging::LogMessage::~LogMessage()
#3 0x55da2dc6666e service_manager::ZygoteHostImpl::Init()
#4 0x55da2c14808c content::ContentMainRunnerImpl::Initialize()
#5 0x55da2c193d1c service_manager::Main()
#6 0x55da2c146661 content::ContentMain()
#7 0x55da29fb21bf ChromeMain
#8 0x7fa40d2e709b __libc_start_main
#9 0x55da29fb202a _start

Received signal 6
#0 0x55da2c5c0a99 base::debug::CollectStackTrace()
#1 0x55da2c5213e3 base::debug::StackTrace::StackTrace()
#2 0x55da2c5c0621 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#3 0x7fa40f785730 <unknown>
#4 0x7fa40d2fa7bb gsignal
#5 0x7fa40d2e5535 abort
#6 0x55da2c5bf465 base::debug::BreakDebugger()
#7 0x55da2c535c27 logging::LogMessage::~LogMessage()
#8 0x55da2dc6666e service_manager::ZygoteHostImpl::Init()
#9 0x55da2c14808c content::ContentMainRunnerImpl::Initialize()
#10 0x55da2c193d1c service_manager::Main()
#11 0x55da2c146661 content::ContentMain()
#12 0x55da29fb21bf ChromeMain
#13 0x7fa40d2e709b __libc_start_main
#14 0x55da29fb202a _start
  r8: 0000000000000000  r9: 00007fff33d548b0 r10: 0000000000000008 r11: 0000000000000246
 r12: 00007fff33d55b78 r13: 00007fff33d54b58 r14: 00007fff33d55b80 r15: 00007fff33d55b88
  di: 0000000000000002  si: 00007fff33d548b0  bp: 00007fff33d54b00  bx: 0000000000000006
  dx: 0000000000000000  ax: 0000000000000000  cx: 00007fa40d2fa7bb  sp: 00007fff33d548b0
  ip: 00007fa40d2fa7bb efl: 0000000000000246 cgf: 002b000000000033 erf: 0000000000000000
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]
Calling _exit(1). Core file will not be generated.


TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

    at onClose (/home/nick/code/WhatDidIBuy/node_modules/puppeteer/lib/Launcher.js:349:14)
    at Interface.<anonymous> (/home/nick/code/WhatDidIBuy/node_modules/puppeteer/lib/Launcher.js:338:50)
    at Interface.emit (node:events:381:22)
    at Interface.close (node:readline:540:8)
    at Socket.onend (node:readline:256:10)
    at Socket.emit (node:events:381:22)
    at endReadableNT (node:internal/streams/readable:1307:12)
    at processTicksAndRejections (node:internal/process/task_queues:81:21)
```